### PR TITLE
GoRouter and Builder with Dependency Updates

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/foundation.dart';
+import 'package:go_router/go_router.dart';
+import 'routes.dart';
+
+final appRouter = GoRouter(
+  routes: $appRoutes,
+  initialLocation: const LessonsListRoute().location,
+  debugLogDiagnostics: kDebugMode,
+);

--- a/lib/features/lesson/model/lesson_definition/lesson_definition.freezed.dart
+++ b/lib/features/lesson/model/lesson_definition/lesson_definition.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,89 +9,63 @@ part of 'lesson_definition.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$LessonDefinition {
-  String get lessonId => throw _privateConstructorUsedError;
-  String get lessonName => throw _privateConstructorUsedError;
-  List<SentencePair> get sentencePairs => throw _privateConstructorUsedError;
+  String get lessonId;
+  String get lessonName;
+  List<SentencePair> get sentencePairs;
 
   /// Create a copy of LessonDefinition
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $LessonDefinitionCopyWith<LessonDefinition> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $LessonDefinitionCopyWith<$Res> {
-  factory $LessonDefinitionCopyWith(
-          LessonDefinition value, $Res Function(LessonDefinition) then) =
-      _$LessonDefinitionCopyWithImpl<$Res, LessonDefinition>;
-  @useResult
-  $Res call(
-      {String lessonId, String lessonName, List<SentencePair> sentencePairs});
-}
-
-/// @nodoc
-class _$LessonDefinitionCopyWithImpl<$Res, $Val extends LessonDefinition>
-    implements $LessonDefinitionCopyWith<$Res> {
-  _$LessonDefinitionCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of LessonDefinition
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $LessonDefinitionCopyWith<LessonDefinition> get copyWith =>
+      _$LessonDefinitionCopyWithImpl<LessonDefinition>(
+          this as LessonDefinition, _$identity);
+
   @override
-  $Res call({
-    Object? lessonId = null,
-    Object? lessonName = null,
-    Object? sentencePairs = null,
-  }) {
-    return _then(_value.copyWith(
-      lessonId: null == lessonId
-          ? _value.lessonId
-          : lessonId // ignore: cast_nullable_to_non_nullable
-              as String,
-      lessonName: null == lessonName
-          ? _value.lessonName
-          : lessonName // ignore: cast_nullable_to_non_nullable
-              as String,
-      sentencePairs: null == sentencePairs
-          ? _value.sentencePairs
-          : sentencePairs // ignore: cast_nullable_to_non_nullable
-              as List<SentencePair>,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is LessonDefinition &&
+            (identical(other.lessonId, lessonId) ||
+                other.lessonId == lessonId) &&
+            (identical(other.lessonName, lessonName) ||
+                other.lessonName == lessonName) &&
+            const DeepCollectionEquality()
+                .equals(other.sentencePairs, sentencePairs));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, lessonId, lessonName,
+      const DeepCollectionEquality().hash(sentencePairs));
+
+  @override
+  String toString() {
+    return 'LessonDefinition(lessonId: $lessonId, lessonName: $lessonName, sentencePairs: $sentencePairs)';
   }
 }
 
 /// @nodoc
-abstract class _$$LessonDefinitionImplCopyWith<$Res>
-    implements $LessonDefinitionCopyWith<$Res> {
-  factory _$$LessonDefinitionImplCopyWith(_$LessonDefinitionImpl value,
-          $Res Function(_$LessonDefinitionImpl) then) =
-      __$$LessonDefinitionImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $LessonDefinitionCopyWith<$Res> {
+  factory $LessonDefinitionCopyWith(
+          LessonDefinition value, $Res Function(LessonDefinition) _then) =
+      _$LessonDefinitionCopyWithImpl;
   @useResult
   $Res call(
       {String lessonId, String lessonName, List<SentencePair> sentencePairs});
 }
 
 /// @nodoc
-class __$$LessonDefinitionImplCopyWithImpl<$Res>
-    extends _$LessonDefinitionCopyWithImpl<$Res, _$LessonDefinitionImpl>
-    implements _$$LessonDefinitionImplCopyWith<$Res> {
-  __$$LessonDefinitionImplCopyWithImpl(_$LessonDefinitionImpl _value,
-      $Res Function(_$LessonDefinitionImpl) _then)
-      : super(_value, _then);
+class _$LessonDefinitionCopyWithImpl<$Res>
+    implements $LessonDefinitionCopyWith<$Res> {
+  _$LessonDefinitionCopyWithImpl(this._self, this._then);
+
+  final LessonDefinition _self;
+  final $Res Function(LessonDefinition) _then;
 
   /// Create a copy of LessonDefinition
   /// with the given fields replaced by the non-null parameter values.
@@ -102,27 +76,190 @@ class __$$LessonDefinitionImplCopyWithImpl<$Res>
     Object? lessonName = null,
     Object? sentencePairs = null,
   }) {
-    return _then(_$LessonDefinitionImpl(
+    return _then(_self.copyWith(
       lessonId: null == lessonId
-          ? _value.lessonId
+          ? _self.lessonId
           : lessonId // ignore: cast_nullable_to_non_nullable
               as String,
       lessonName: null == lessonName
-          ? _value.lessonName
+          ? _self.lessonName
           : lessonName // ignore: cast_nullable_to_non_nullable
               as String,
       sentencePairs: null == sentencePairs
-          ? _value._sentencePairs
+          ? _self.sentencePairs
           : sentencePairs // ignore: cast_nullable_to_non_nullable
               as List<SentencePair>,
     ));
   }
 }
 
+/// Adds pattern-matching-related methods to [LessonDefinition].
+extension LessonDefinitionPatterns on LessonDefinition {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_LessonDefinition value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _LessonDefinition() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_LessonDefinition value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LessonDefinition():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_LessonDefinition value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LessonDefinition() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String lessonId, String lessonName,
+            List<SentencePair> sentencePairs)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _LessonDefinition() when $default != null:
+        return $default(_that.lessonId, _that.lessonName, _that.sentencePairs);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String lessonId, String lessonName,
+            List<SentencePair> sentencePairs)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LessonDefinition():
+        return $default(_that.lessonId, _that.lessonName, _that.sentencePairs);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String lessonId, String lessonName,
+            List<SentencePair> sentencePairs)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _LessonDefinition() when $default != null:
+        return $default(_that.lessonId, _that.lessonName, _that.sentencePairs);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 
-class _$LessonDefinitionImpl implements _LessonDefinition {
-  const _$LessonDefinitionImpl(
+class _LessonDefinition implements LessonDefinition {
+  const _LessonDefinition(
       {required this.lessonId,
       required this.lessonName,
       required final List<SentencePair> sentencePairs})
@@ -140,16 +277,19 @@ class _$LessonDefinitionImpl implements _LessonDefinition {
     return EqualUnmodifiableListView(_sentencePairs);
   }
 
+  /// Create a copy of LessonDefinition
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'LessonDefinition(lessonId: $lessonId, lessonName: $lessonName, sentencePairs: $sentencePairs)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$LessonDefinitionCopyWith<_LessonDefinition> get copyWith =>
+      __$LessonDefinitionCopyWithImpl<_LessonDefinition>(this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$LessonDefinitionImpl &&
+            other is _LessonDefinition &&
             (identical(other.lessonId, lessonId) ||
                 other.lessonId == lessonId) &&
             (identical(other.lessonName, lessonName) ||
@@ -162,34 +302,56 @@ class _$LessonDefinitionImpl implements _LessonDefinition {
   int get hashCode => Object.hash(runtimeType, lessonId, lessonName,
       const DeepCollectionEquality().hash(_sentencePairs));
 
+  @override
+  String toString() {
+    return 'LessonDefinition(lessonId: $lessonId, lessonName: $lessonName, sentencePairs: $sentencePairs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$LessonDefinitionCopyWith<$Res>
+    implements $LessonDefinitionCopyWith<$Res> {
+  factory _$LessonDefinitionCopyWith(
+          _LessonDefinition value, $Res Function(_LessonDefinition) _then) =
+      __$LessonDefinitionCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {String lessonId, String lessonName, List<SentencePair> sentencePairs});
+}
+
+/// @nodoc
+class __$LessonDefinitionCopyWithImpl<$Res>
+    implements _$LessonDefinitionCopyWith<$Res> {
+  __$LessonDefinitionCopyWithImpl(this._self, this._then);
+
+  final _LessonDefinition _self;
+  final $Res Function(_LessonDefinition) _then;
+
   /// Create a copy of LessonDefinition
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$LessonDefinitionImplCopyWith<_$LessonDefinitionImpl> get copyWith =>
-      __$$LessonDefinitionImplCopyWithImpl<_$LessonDefinitionImpl>(
-          this, _$identity);
+  $Res call({
+    Object? lessonId = null,
+    Object? lessonName = null,
+    Object? sentencePairs = null,
+  }) {
+    return _then(_LessonDefinition(
+      lessonId: null == lessonId
+          ? _self.lessonId
+          : lessonId // ignore: cast_nullable_to_non_nullable
+              as String,
+      lessonName: null == lessonName
+          ? _self.lessonName
+          : lessonName // ignore: cast_nullable_to_non_nullable
+              as String,
+      sentencePairs: null == sentencePairs
+          ? _self._sentencePairs
+          : sentencePairs // ignore: cast_nullable_to_non_nullable
+              as List<SentencePair>,
+    ));
+  }
 }
 
-abstract class _LessonDefinition implements LessonDefinition {
-  const factory _LessonDefinition(
-          {required final String lessonId,
-          required final String lessonName,
-          required final List<SentencePair> sentencePairs}) =
-      _$LessonDefinitionImpl;
-
-  @override
-  String get lessonId;
-  @override
-  String get lessonName;
-  @override
-  List<SentencePair> get sentencePairs;
-
-  /// Create a copy of LessonDefinition
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$LessonDefinitionImplCopyWith<_$LessonDefinitionImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/features/lesson/model/sentence_pair/sentence_pair.freezed.dart
+++ b/lib/features/lesson/model/sentence_pair/sentence_pair.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,135 +9,30 @@ part of 'sentence_pair.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
-
-SentencePair _$SentencePairFromJson(Map<String, dynamic> json) {
-  return _SentencePair.fromJson(json);
-}
 
 /// @nodoc
 mixin _$SentencePair {
-  String get english => throw _privateConstructorUsedError;
-  String get irish => throw _privateConstructorUsedError;
-
-  /// Serializes this SentencePair to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  String get english;
+  String get irish;
 
   /// Create a copy of SentencePair
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $SentencePairCopyWith<SentencePair> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+      _$SentencePairCopyWithImpl<SentencePair>(
+          this as SentencePair, _$identity);
 
-/// @nodoc
-abstract class $SentencePairCopyWith<$Res> {
-  factory $SentencePairCopyWith(
-          SentencePair value, $Res Function(SentencePair) then) =
-      _$SentencePairCopyWithImpl<$Res, SentencePair>;
-  @useResult
-  $Res call({String english, String irish});
-}
-
-/// @nodoc
-class _$SentencePairCopyWithImpl<$Res, $Val extends SentencePair>
-    implements $SentencePairCopyWith<$Res> {
-  _$SentencePairCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of SentencePair
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? english = null,
-    Object? irish = null,
-  }) {
-    return _then(_value.copyWith(
-      english: null == english
-          ? _value.english
-          : english // ignore: cast_nullable_to_non_nullable
-              as String,
-      irish: null == irish
-          ? _value.irish
-          : irish // ignore: cast_nullable_to_non_nullable
-              as String,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
-abstract class _$$SentencePairImplCopyWith<$Res>
-    implements $SentencePairCopyWith<$Res> {
-  factory _$$SentencePairImplCopyWith(
-          _$SentencePairImpl value, $Res Function(_$SentencePairImpl) then) =
-      __$$SentencePairImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String english, String irish});
-}
-
-/// @nodoc
-class __$$SentencePairImplCopyWithImpl<$Res>
-    extends _$SentencePairCopyWithImpl<$Res, _$SentencePairImpl>
-    implements _$$SentencePairImplCopyWith<$Res> {
-  __$$SentencePairImplCopyWithImpl(
-      _$SentencePairImpl _value, $Res Function(_$SentencePairImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of SentencePair
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? english = null,
-    Object? irish = null,
-  }) {
-    return _then(_$SentencePairImpl(
-      english: null == english
-          ? _value.english
-          : english // ignore: cast_nullable_to_non_nullable
-              as String,
-      irish: null == irish
-          ? _value.irish
-          : irish // ignore: cast_nullable_to_non_nullable
-              as String,
-    ));
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$SentencePairImpl extends _SentencePair {
-  const _$SentencePairImpl({this.english = '', this.irish = ''}) : super._();
-
-  factory _$SentencePairImpl.fromJson(Map<String, dynamic> json) =>
-      _$$SentencePairImplFromJson(json);
-
-  @override
-  @JsonKey()
-  final String english;
-  @override
-  @JsonKey()
-  final String irish;
-
-  @override
-  String toString() {
-    return 'SentencePair(english: $english, irish: $irish)';
-  }
+  /// Serializes this SentencePair to a JSON map.
+  Map<String, dynamic> toJson();
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$SentencePairImpl &&
+            other is SentencePair &&
             (identical(other.english, english) || other.english == english) &&
             (identical(other.irish, irish) || other.irish == irish));
   }
@@ -146,39 +41,292 @@ class _$SentencePairImpl extends _SentencePair {
   @override
   int get hashCode => Object.hash(runtimeType, english, irish);
 
-  /// Create a copy of SentencePair
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  @pragma('vm:prefer-inline')
-  _$$SentencePairImplCopyWith<_$SentencePairImpl> get copyWith =>
-      __$$SentencePairImplCopyWithImpl<_$SentencePairImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$SentencePairImplToJson(
-      this,
-    );
+  String toString() {
+    return 'SentencePair(english: $english, irish: $irish)';
   }
 }
 
-abstract class _SentencePair extends SentencePair {
-  const factory _SentencePair({final String english, final String irish}) =
-      _$SentencePairImpl;
-  const _SentencePair._() : super._();
+/// @nodoc
+abstract mixin class $SentencePairCopyWith<$Res> {
+  factory $SentencePairCopyWith(
+          SentencePair value, $Res Function(SentencePair) _then) =
+      _$SentencePairCopyWithImpl;
+  @useResult
+  $Res call({String english, String irish});
+}
 
-  factory _SentencePair.fromJson(Map<String, dynamic> json) =
-      _$SentencePairImpl.fromJson;
+/// @nodoc
+class _$SentencePairCopyWithImpl<$Res> implements $SentencePairCopyWith<$Res> {
+  _$SentencePairCopyWithImpl(this._self, this._then);
+
+  final SentencePair _self;
+  final $Res Function(SentencePair) _then;
+
+  /// Create a copy of SentencePair
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? english = null,
+    Object? irish = null,
+  }) {
+    return _then(_self.copyWith(
+      english: null == english
+          ? _self.english
+          : english // ignore: cast_nullable_to_non_nullable
+              as String,
+      irish: null == irish
+          ? _self.irish
+          : irish // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [SentencePair].
+extension SentencePairPatterns on SentencePair {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_SentencePair value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SentencePair() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_SentencePair value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SentencePair():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_SentencePair value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SentencePair() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(String english, String irish)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _SentencePair() when $default != null:
+        return $default(_that.english, _that.irish);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(String english, String irish) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SentencePair():
+        return $default(_that.english, _that.irish);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(String english, String irish)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _SentencePair() when $default != null:
+        return $default(_that.english, _that.irish);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _SentencePair extends SentencePair {
+  const _SentencePair({this.english = '', this.irish = ''}) : super._();
+  factory _SentencePair.fromJson(Map<String, dynamic> json) =>
+      _$SentencePairFromJson(json);
 
   @override
-  String get english;
+  @JsonKey()
+  final String english;
   @override
-  String get irish;
+  @JsonKey()
+  final String irish;
 
   /// Create a copy of SentencePair
   /// with the given fields replaced by the non-null parameter values.
   @override
   @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$SentencePairImplCopyWith<_$SentencePairImpl> get copyWith =>
-      throw _privateConstructorUsedError;
+  @pragma('vm:prefer-inline')
+  _$SentencePairCopyWith<_SentencePair> get copyWith =>
+      __$SentencePairCopyWithImpl<_SentencePair>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$SentencePairToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _SentencePair &&
+            (identical(other.english, english) || other.english == english) &&
+            (identical(other.irish, irish) || other.irish == irish));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, english, irish);
+
+  @override
+  String toString() {
+    return 'SentencePair(english: $english, irish: $irish)';
+  }
 }
+
+/// @nodoc
+abstract mixin class _$SentencePairCopyWith<$Res>
+    implements $SentencePairCopyWith<$Res> {
+  factory _$SentencePairCopyWith(
+          _SentencePair value, $Res Function(_SentencePair) _then) =
+      __$SentencePairCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String english, String irish});
+}
+
+/// @nodoc
+class __$SentencePairCopyWithImpl<$Res>
+    implements _$SentencePairCopyWith<$Res> {
+  __$SentencePairCopyWithImpl(this._self, this._then);
+
+  final _SentencePair _self;
+  final $Res Function(_SentencePair) _then;
+
+  /// Create a copy of SentencePair
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? english = null,
+    Object? irish = null,
+  }) {
+    return _then(_SentencePair(
+      english: null == english
+          ? _self.english
+          : english // ignore: cast_nullable_to_non_nullable
+              as String,
+      irish: null == irish
+          ? _self.irish
+          : irish // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/lib/features/lesson/model/sentence_pair/sentence_pair.g.dart
+++ b/lib/features/lesson/model/sentence_pair/sentence_pair.g.dart
@@ -6,13 +6,13 @@ part of 'sentence_pair.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$SentencePairImpl _$$SentencePairImplFromJson(Map<String, dynamic> json) =>
-    _$SentencePairImpl(
+_SentencePair _$SentencePairFromJson(Map<String, dynamic> json) =>
+    _SentencePair(
       english: json['english'] as String? ?? '',
       irish: json['irish'] as String? ?? '',
     );
 
-Map<String, dynamic> _$$SentencePairImplToJson(_$SentencePairImpl instance) =>
+Map<String, dynamic> _$SentencePairToJson(_SentencePair instance) =>
     <String, dynamic>{
       'english': instance.english,
       'irish': instance.irish,

--- a/lib/features/lesson/presentation/controller/connectivity_controller.g.dart
+++ b/lib/features/lesson/presentation/controller/connectivity_controller.g.dart
@@ -6,22 +6,56 @@ part of 'connectivity_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(ConnectivityController)
+const connectivityControllerProvider = ConnectivityControllerProvider._();
+
+final class ConnectivityControllerProvider
+    extends $NotifierProvider<ConnectivityController, ConnectivityState> {
+  const ConnectivityControllerProvider._()
+      : super(
+          from: null,
+          argument: null,
+          retry: null,
+          name: r'connectivityControllerProvider',
+          isAutoDispose: true,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$connectivityControllerHash();
+
+  @$internal
+  @override
+  ConnectivityController create() => ConnectivityController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ConnectivityState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ConnectivityState>(value),
+    );
+  }
+}
+
 String _$connectivityControllerHash() =>
     r'8b657ab12416b0e43365e3a875b73d99c6cc4a68';
 
-/// See also [ConnectivityController].
-@ProviderFor(ConnectivityController)
-final connectivityControllerProvider = AutoDisposeNotifierProvider<
-    ConnectivityController, ConnectivityState>.internal(
-  ConnectivityController.new,
-  name: r'connectivityControllerProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$connectivityControllerHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
-
-typedef _$ConnectivityController = AutoDisposeNotifier<ConnectivityState>;
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package
+abstract class _$ConnectivityController extends $Notifier<ConnectivityState> {
+  ConnectivityState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref as $Ref<ConnectivityState, ConnectivityState>;
+    final element = ref.element as $ClassProviderElement<
+        AnyNotifier<ConnectivityState, ConnectivityState>,
+        ConnectivityState,
+        Object?,
+        Object?>;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/lesson/presentation/controller/interactive_exercise_controller.g.dart
+++ b/lib/features/lesson/presentation/controller/interactive_exercise_controller.g.dart
@@ -6,178 +6,110 @@ part of 'interactive_exercise_controller.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$interactiveExerciseControllerHash() =>
-    r'b92584531c9a98293445f8f02093488476b461d3';
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
 
-/// Copied from Dart SDK
-class _SystemHash {
-  _SystemHash._();
-
-  static int combine(int hash, int value) {
-    // ignore: parameter_assignments
-    hash = 0x1fffffff & (hash + value);
-    // ignore: parameter_assignments
-    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
-    return hash ^ (hash >> 6);
-  }
-
-  static int finish(int hash) {
-    // ignore: parameter_assignments
-    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
-    // ignore: parameter_assignments
-    hash = hash ^ (hash >> 11);
-    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
-  }
-}
-
-abstract class _$InteractiveExerciseController
-    extends BuildlessAutoDisposeNotifier<InteractiveExerciseState> {
-  late final List<SentencePair> sentences;
-
-  InteractiveExerciseState build(
-    List<SentencePair> sentences,
-  );
-}
-
-/// See also [InteractiveExerciseController].
 @ProviderFor(InteractiveExerciseController)
 const interactiveExerciseControllerProvider =
-    InteractiveExerciseControllerFamily();
+    InteractiveExerciseControllerFamily._();
 
-/// See also [InteractiveExerciseController].
-class InteractiveExerciseControllerFamily
-    extends Family<InteractiveExerciseState> {
-  /// See also [InteractiveExerciseController].
-  const InteractiveExerciseControllerFamily();
-
-  /// See also [InteractiveExerciseController].
-  InteractiveExerciseControllerProvider call(
-    List<SentencePair> sentences,
-  ) {
-    return InteractiveExerciseControllerProvider(
-      sentences,
-    );
-  }
-
-  @override
-  InteractiveExerciseControllerProvider getProviderOverride(
-    covariant InteractiveExerciseControllerProvider provider,
-  ) {
-    return call(
-      provider.sentences,
-    );
-  }
-
-  static const Iterable<ProviderOrFamily>? _dependencies = null;
-
-  @override
-  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
-
-  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
-
-  @override
-  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
-      _allTransitiveDependencies;
-
-  @override
-  String? get name => r'interactiveExerciseControllerProvider';
-}
-
-/// See also [InteractiveExerciseController].
-class InteractiveExerciseControllerProvider
-    extends AutoDisposeNotifierProviderImpl<InteractiveExerciseController,
-        InteractiveExerciseState> {
-  /// See also [InteractiveExerciseController].
-  InteractiveExerciseControllerProvider(
-    List<SentencePair> sentences,
-  ) : this._internal(
-          () => InteractiveExerciseController()..sentences = sentences,
-          from: interactiveExerciseControllerProvider,
+final class InteractiveExerciseControllerProvider extends $NotifierProvider<
+    InteractiveExerciseController, InteractiveExerciseState> {
+  const InteractiveExerciseControllerProvider._(
+      {required InteractiveExerciseControllerFamily super.from,
+      required List<SentencePair> super.argument})
+      : super(
+          retry: null,
           name: r'interactiveExerciseControllerProvider',
-          debugGetCreateSourceHash:
-              const bool.fromEnvironment('dart.vm.product')
-                  ? null
-                  : _$interactiveExerciseControllerHash,
-          dependencies: InteractiveExerciseControllerFamily._dependencies,
-          allTransitiveDependencies:
-              InteractiveExerciseControllerFamily._allTransitiveDependencies,
-          sentences: sentences,
+          isAutoDispose: true,
+          dependencies: null,
+          $allTransitiveDependencies: null,
         );
 
-  InteractiveExerciseControllerProvider._internal(
-    super._createNotifier, {
-    required super.name,
-    required super.dependencies,
-    required super.allTransitiveDependencies,
-    required super.debugGetCreateSourceHash,
-    required super.from,
-    required this.sentences,
-  }) : super.internal();
-
-  final List<SentencePair> sentences;
+  @override
+  String debugGetCreateSourceHash() => _$interactiveExerciseControllerHash();
 
   @override
-  InteractiveExerciseState runNotifierBuild(
-    covariant InteractiveExerciseController notifier,
-  ) {
-    return notifier.build(
-      sentences,
-    );
+  String toString() {
+    return r'interactiveExerciseControllerProvider'
+        ''
+        '($argument)';
   }
 
+  @$internal
   @override
-  Override overrideWith(InteractiveExerciseController Function() create) {
-    return ProviderOverride(
+  InteractiveExerciseController create() => InteractiveExerciseController();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(InteractiveExerciseState value) {
+    return $ProviderOverride(
       origin: this,
-      override: InteractiveExerciseControllerProvider._internal(
-        () => create()..sentences = sentences,
-        from: from,
-        name: null,
-        dependencies: null,
-        allTransitiveDependencies: null,
-        debugGetCreateSourceHash: null,
-        sentences: sentences,
-      ),
+      providerOverride: $SyncValueProvider<InteractiveExerciseState>(value),
     );
-  }
-
-  @override
-  AutoDisposeNotifierProviderElement<InteractiveExerciseController,
-      InteractiveExerciseState> createElement() {
-    return _InteractiveExerciseControllerProviderElement(this);
   }
 
   @override
   bool operator ==(Object other) {
     return other is InteractiveExerciseControllerProvider &&
-        other.sentences == sentences;
+        other.argument == argument;
   }
 
   @override
   int get hashCode {
-    var hash = _SystemHash.combine(0, runtimeType.hashCode);
-    hash = _SystemHash.combine(hash, sentences.hashCode);
-
-    return _SystemHash.finish(hash);
+    return argument.hashCode;
   }
 }
 
-@Deprecated('Will be removed in 3.0. Use Ref instead')
-// ignore: unused_element
-mixin InteractiveExerciseControllerRef
-    on AutoDisposeNotifierProviderRef<InteractiveExerciseState> {
-  /// The parameter `sentences` of this provider.
-  List<SentencePair> get sentences;
-}
+String _$interactiveExerciseControllerHash() =>
+    r'b92584531c9a98293445f8f02093488476b461d3';
 
-class _InteractiveExerciseControllerProviderElement
-    extends AutoDisposeNotifierProviderElement<InteractiveExerciseController,
-        InteractiveExerciseState> with InteractiveExerciseControllerRef {
-  _InteractiveExerciseControllerProviderElement(super.provider);
+final class InteractiveExerciseControllerFamily extends $Family
+    with
+        $ClassFamilyOverride<
+            InteractiveExerciseController,
+            InteractiveExerciseState,
+            InteractiveExerciseState,
+            InteractiveExerciseState,
+            List<SentencePair>> {
+  const InteractiveExerciseControllerFamily._()
+      : super(
+          retry: null,
+          name: r'interactiveExerciseControllerProvider',
+          dependencies: null,
+          $allTransitiveDependencies: null,
+          isAutoDispose: true,
+        );
+
+  InteractiveExerciseControllerProvider call(
+    List<SentencePair> sentences,
+  ) =>
+      InteractiveExerciseControllerProvider._(argument: sentences, from: this);
 
   @override
-  List<SentencePair> get sentences =>
-      (origin as InteractiveExerciseControllerProvider).sentences;
+  String toString() => r'interactiveExerciseControllerProvider';
 }
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package
+
+abstract class _$InteractiveExerciseController
+    extends $Notifier<InteractiveExerciseState> {
+  late final _$args = ref.$arg as List<SentencePair>;
+  List<SentencePair> get sentences => _$args;
+
+  InteractiveExerciseState build(
+    List<SentencePair> sentences,
+  );
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build(
+      _$args,
+    );
+    final ref =
+        this.ref as $Ref<InteractiveExerciseState, InteractiveExerciseState>;
+    final element = ref.element as $ClassProviderElement<
+        AnyNotifier<InteractiveExerciseState, InteractiveExerciseState>,
+        InteractiveExerciseState,
+        Object?,
+        Object?>;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/lesson/presentation/state/connectivity_state.dart
+++ b/lib/features/lesson/presentation/state/connectivity_state.dart
@@ -9,7 +9,7 @@ enum NetQuality { online, poor, offline, invalid }
 /// Includes convenience getters [isOnline] [isOffline] and [valid]
 
 @freezed
-class ConnectivityState with _$ConnectivityState {
+abstract class ConnectivityState with _$ConnectivityState {
   const ConnectivityState._();
 
   const factory ConnectivityState({

--- a/lib/features/lesson/presentation/state/connectivity_state.freezed.dart
+++ b/lib/features/lesson/presentation/state/connectivity_state.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,125 +9,27 @@ part of 'connectivity_state.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$ConnectivityState {
-  NetQuality get status => throw _privateConstructorUsedError;
-  double get lastLatencyMs => throw _privateConstructorUsedError;
+  NetQuality get status;
+  double get lastLatencyMs;
 
   /// Create a copy of ConnectivityState
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
   $ConnectivityStateCopyWith<ConnectivityState> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $ConnectivityStateCopyWith<$Res> {
-  factory $ConnectivityStateCopyWith(
-          ConnectivityState value, $Res Function(ConnectivityState) then) =
-      _$ConnectivityStateCopyWithImpl<$Res, ConnectivityState>;
-  @useResult
-  $Res call({NetQuality status, double lastLatencyMs});
-}
-
-/// @nodoc
-class _$ConnectivityStateCopyWithImpl<$Res, $Val extends ConnectivityState>
-    implements $ConnectivityStateCopyWith<$Res> {
-  _$ConnectivityStateCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of ConnectivityState
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? status = null,
-    Object? lastLatencyMs = null,
-  }) {
-    return _then(_value.copyWith(
-      status: null == status
-          ? _value.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as NetQuality,
-      lastLatencyMs: null == lastLatencyMs
-          ? _value.lastLatencyMs
-          : lastLatencyMs // ignore: cast_nullable_to_non_nullable
-              as double,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
-abstract class _$$ConnectivityStateImplCopyWith<$Res>
-    implements $ConnectivityStateCopyWith<$Res> {
-  factory _$$ConnectivityStateImplCopyWith(_$ConnectivityStateImpl value,
-          $Res Function(_$ConnectivityStateImpl) then) =
-      __$$ConnectivityStateImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({NetQuality status, double lastLatencyMs});
-}
-
-/// @nodoc
-class __$$ConnectivityStateImplCopyWithImpl<$Res>
-    extends _$ConnectivityStateCopyWithImpl<$Res, _$ConnectivityStateImpl>
-    implements _$$ConnectivityStateImplCopyWith<$Res> {
-  __$$ConnectivityStateImplCopyWithImpl(_$ConnectivityStateImpl _value,
-      $Res Function(_$ConnectivityStateImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of ConnectivityState
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? status = null,
-    Object? lastLatencyMs = null,
-  }) {
-    return _then(_$ConnectivityStateImpl(
-      status: null == status
-          ? _value.status
-          : status // ignore: cast_nullable_to_non_nullable
-              as NetQuality,
-      lastLatencyMs: null == lastLatencyMs
-          ? _value.lastLatencyMs
-          : lastLatencyMs // ignore: cast_nullable_to_non_nullable
-              as double,
-    ));
-  }
-}
-
-/// @nodoc
-
-class _$ConnectivityStateImpl extends _ConnectivityState {
-  const _$ConnectivityStateImpl(
-      {required this.status, required this.lastLatencyMs})
-      : super._();
-
-  @override
-  final NetQuality status;
-  @override
-  final double lastLatencyMs;
-
-  @override
-  String toString() {
-    return 'ConnectivityState(status: $status, lastLatencyMs: $lastLatencyMs)';
-  }
+      _$ConnectivityStateCopyWithImpl<ConnectivityState>(
+          this as ConnectivityState, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$ConnectivityStateImpl &&
+            other is ConnectivityState &&
             (identical(other.status, status) || other.status == status) &&
             (identical(other.lastLatencyMs, lastLatencyMs) ||
                 other.lastLatencyMs == lastLatencyMs));
@@ -136,31 +38,283 @@ class _$ConnectivityStateImpl extends _ConnectivityState {
   @override
   int get hashCode => Object.hash(runtimeType, status, lastLatencyMs);
 
+  @override
+  String toString() {
+    return 'ConnectivityState(status: $status, lastLatencyMs: $lastLatencyMs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $ConnectivityStateCopyWith<$Res> {
+  factory $ConnectivityStateCopyWith(
+          ConnectivityState value, $Res Function(ConnectivityState) _then) =
+      _$ConnectivityStateCopyWithImpl;
+  @useResult
+  $Res call({NetQuality status, double lastLatencyMs});
+}
+
+/// @nodoc
+class _$ConnectivityStateCopyWithImpl<$Res>
+    implements $ConnectivityStateCopyWith<$Res> {
+  _$ConnectivityStateCopyWithImpl(this._self, this._then);
+
+  final ConnectivityState _self;
+  final $Res Function(ConnectivityState) _then;
+
   /// Create a copy of ConnectivityState
   /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? status = null,
+    Object? lastLatencyMs = null,
+  }) {
+    return _then(_self.copyWith(
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as NetQuality,
+      lastLatencyMs: null == lastLatencyMs
+          ? _self.lastLatencyMs
+          : lastLatencyMs // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// Adds pattern-matching-related methods to [ConnectivityState].
+extension ConnectivityStatePatterns on ConnectivityState {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_ConnectivityState value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ConnectivityState() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_ConnectivityState value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ConnectivityState():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_ConnectivityState value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ConnectivityState() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(NetQuality status, double lastLatencyMs)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _ConnectivityState() when $default != null:
+        return $default(_that.status, _that.lastLatencyMs);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(NetQuality status, double lastLatencyMs) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ConnectivityState():
+        return $default(_that.status, _that.lastLatencyMs);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(NetQuality status, double lastLatencyMs)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _ConnectivityState() when $default != null:
+        return $default(_that.status, _that.lastLatencyMs);
+      case _:
+        return null;
+    }
+  }
+}
+
+/// @nodoc
+
+class _ConnectivityState extends ConnectivityState {
+  const _ConnectivityState({required this.status, required this.lastLatencyMs})
+      : super._();
+
+  @override
+  final NetQuality status;
+  @override
+  final double lastLatencyMs;
+
+  /// Create a copy of ConnectivityState
+  /// with the given fields replaced by the non-null parameter values.
+  @override
   @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ConnectivityStateCopyWith<_ConnectivityState> get copyWith =>
+      __$ConnectivityStateCopyWithImpl<_ConnectivityState>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _ConnectivityState &&
+            (identical(other.status, status) || other.status == status) &&
+            (identical(other.lastLatencyMs, lastLatencyMs) ||
+                other.lastLatencyMs == lastLatencyMs));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, status, lastLatencyMs);
+
+  @override
+  String toString() {
+    return 'ConnectivityState(status: $status, lastLatencyMs: $lastLatencyMs)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ConnectivityStateCopyWith<$Res>
+    implements $ConnectivityStateCopyWith<$Res> {
+  factory _$ConnectivityStateCopyWith(
+          _ConnectivityState value, $Res Function(_ConnectivityState) _then) =
+      __$ConnectivityStateCopyWithImpl;
+  @override
+  @useResult
+  $Res call({NetQuality status, double lastLatencyMs});
+}
+
+/// @nodoc
+class __$ConnectivityStateCopyWithImpl<$Res>
+    implements _$ConnectivityStateCopyWith<$Res> {
+  __$ConnectivityStateCopyWithImpl(this._self, this._then);
+
+  final _ConnectivityState _self;
+  final $Res Function(_ConnectivityState) _then;
+
+  /// Create a copy of ConnectivityState
+  /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  _$$ConnectivityStateImplCopyWith<_$ConnectivityStateImpl> get copyWith =>
-      __$$ConnectivityStateImplCopyWithImpl<_$ConnectivityStateImpl>(
-          this, _$identity);
+  $Res call({
+    Object? status = null,
+    Object? lastLatencyMs = null,
+  }) {
+    return _then(_ConnectivityState(
+      status: null == status
+          ? _self.status
+          : status // ignore: cast_nullable_to_non_nullable
+              as NetQuality,
+      lastLatencyMs: null == lastLatencyMs
+          ? _self.lastLatencyMs
+          : lastLatencyMs // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
 }
 
-abstract class _ConnectivityState extends ConnectivityState {
-  const factory _ConnectivityState(
-      {required final NetQuality status,
-      required final double lastLatencyMs}) = _$ConnectivityStateImpl;
-  const _ConnectivityState._() : super._();
-
-  @override
-  NetQuality get status;
-  @override
-  double get lastLatencyMs;
-
-  /// Create a copy of ConnectivityState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$ConnectivityStateImplCopyWith<_$ConnectivityStateImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/features/lesson/presentation/state/interactive_exercise_state.dart
+++ b/lib/features/lesson/presentation/state/interactive_exercise_state.dart
@@ -6,7 +6,7 @@ part 'interactive_exercise_state.freezed.dart';
 enum LessonState { playing, completed, finished }
 
 @freezed
-class InteractiveExerciseState with _$InteractiveExerciseState {
+abstract class InteractiveExerciseState with _$InteractiveExerciseState {
   const InteractiveExerciseState._();
 
   const factory InteractiveExerciseState({

--- a/lib/features/lesson/presentation/state/interactive_exercise_state.freezed.dart
+++ b/lib/features/lesson/presentation/state/interactive_exercise_state.freezed.dart
@@ -1,5 +1,5 @@
-// coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
@@ -9,137 +9,85 @@ part of 'interactive_exercise_state.dart';
 // FreezedGenerator
 // **************************************************************************
 
+// dart format off
 T _$identity<T>(T value) => value;
-
-final _privateConstructorUsedError = UnsupportedError(
-    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 /// @nodoc
 mixin _$InteractiveExerciseState {
-  List<SentencePair> get sentences => throw _privateConstructorUsedError;
-  int get currentSentenceIndex => throw _privateConstructorUsedError;
-  int get currentWordIndex => throw _privateConstructorUsedError;
-  String get currentUserInput => throw _privateConstructorUsedError;
-  List<String> get revealedIrishWords => throw _privateConstructorUsedError;
-  List<bool> get completedSentences => throw _privateConstructorUsedError;
-  LessonState get lessonState => throw _privateConstructorUsedError;
-  bool get isCurrentWordCorrect => throw _privateConstructorUsedError;
-  bool get isWordRevealed => throw _privateConstructorUsedError;
-  bool get isShiftEnabled => throw _privateConstructorUsedError;
-  bool get isFadaEnabled => throw _privateConstructorUsedError;
+  List<SentencePair> get sentences;
+  int get currentSentenceIndex;
+  int get currentWordIndex;
+  String get currentUserInput;
+  List<String> get revealedIrishWords;
+  List<bool> get completedSentences;
+  LessonState get lessonState;
+  bool get isCurrentWordCorrect;
+  bool get isWordRevealed;
+  bool get isShiftEnabled;
+  bool get isFadaEnabled;
 
   /// Create a copy of InteractiveExerciseState
   /// with the given fields replaced by the non-null parameter values.
   @JsonKey(includeFromJson: false, includeToJson: false)
-  $InteractiveExerciseStateCopyWith<InteractiveExerciseState> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $InteractiveExerciseStateCopyWith<$Res> {
-  factory $InteractiveExerciseStateCopyWith(InteractiveExerciseState value,
-          $Res Function(InteractiveExerciseState) then) =
-      _$InteractiveExerciseStateCopyWithImpl<$Res, InteractiveExerciseState>;
-  @useResult
-  $Res call(
-      {List<SentencePair> sentences,
-      int currentSentenceIndex,
-      int currentWordIndex,
-      String currentUserInput,
-      List<String> revealedIrishWords,
-      List<bool> completedSentences,
-      LessonState lessonState,
-      bool isCurrentWordCorrect,
-      bool isWordRevealed,
-      bool isShiftEnabled,
-      bool isFadaEnabled});
-}
-
-/// @nodoc
-class _$InteractiveExerciseStateCopyWithImpl<$Res,
-        $Val extends InteractiveExerciseState>
-    implements $InteractiveExerciseStateCopyWith<$Res> {
-  _$InteractiveExerciseStateCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of InteractiveExerciseState
-  /// with the given fields replaced by the non-null parameter values.
   @pragma('vm:prefer-inline')
+  $InteractiveExerciseStateCopyWith<InteractiveExerciseState> get copyWith =>
+      _$InteractiveExerciseStateCopyWithImpl<InteractiveExerciseState>(
+          this as InteractiveExerciseState, _$identity);
+
   @override
-  $Res call({
-    Object? sentences = null,
-    Object? currentSentenceIndex = null,
-    Object? currentWordIndex = null,
-    Object? currentUserInput = null,
-    Object? revealedIrishWords = null,
-    Object? completedSentences = null,
-    Object? lessonState = null,
-    Object? isCurrentWordCorrect = null,
-    Object? isWordRevealed = null,
-    Object? isShiftEnabled = null,
-    Object? isFadaEnabled = null,
-  }) {
-    return _then(_value.copyWith(
-      sentences: null == sentences
-          ? _value.sentences
-          : sentences // ignore: cast_nullable_to_non_nullable
-              as List<SentencePair>,
-      currentSentenceIndex: null == currentSentenceIndex
-          ? _value.currentSentenceIndex
-          : currentSentenceIndex // ignore: cast_nullable_to_non_nullable
-              as int,
-      currentWordIndex: null == currentWordIndex
-          ? _value.currentWordIndex
-          : currentWordIndex // ignore: cast_nullable_to_non_nullable
-              as int,
-      currentUserInput: null == currentUserInput
-          ? _value.currentUserInput
-          : currentUserInput // ignore: cast_nullable_to_non_nullable
-              as String,
-      revealedIrishWords: null == revealedIrishWords
-          ? _value.revealedIrishWords
-          : revealedIrishWords // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      completedSentences: null == completedSentences
-          ? _value.completedSentences
-          : completedSentences // ignore: cast_nullable_to_non_nullable
-              as List<bool>,
-      lessonState: null == lessonState
-          ? _value.lessonState
-          : lessonState // ignore: cast_nullable_to_non_nullable
-              as LessonState,
-      isCurrentWordCorrect: null == isCurrentWordCorrect
-          ? _value.isCurrentWordCorrect
-          : isCurrentWordCorrect // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isWordRevealed: null == isWordRevealed
-          ? _value.isWordRevealed
-          : isWordRevealed // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isShiftEnabled: null == isShiftEnabled
-          ? _value.isShiftEnabled
-          : isShiftEnabled // ignore: cast_nullable_to_non_nullable
-              as bool,
-      isFadaEnabled: null == isFadaEnabled
-          ? _value.isFadaEnabled
-          : isFadaEnabled // ignore: cast_nullable_to_non_nullable
-              as bool,
-    ) as $Val);
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is InteractiveExerciseState &&
+            const DeepCollectionEquality().equals(other.sentences, sentences) &&
+            (identical(other.currentSentenceIndex, currentSentenceIndex) ||
+                other.currentSentenceIndex == currentSentenceIndex) &&
+            (identical(other.currentWordIndex, currentWordIndex) ||
+                other.currentWordIndex == currentWordIndex) &&
+            (identical(other.currentUserInput, currentUserInput) ||
+                other.currentUserInput == currentUserInput) &&
+            const DeepCollectionEquality()
+                .equals(other.revealedIrishWords, revealedIrishWords) &&
+            const DeepCollectionEquality()
+                .equals(other.completedSentences, completedSentences) &&
+            (identical(other.lessonState, lessonState) ||
+                other.lessonState == lessonState) &&
+            (identical(other.isCurrentWordCorrect, isCurrentWordCorrect) ||
+                other.isCurrentWordCorrect == isCurrentWordCorrect) &&
+            (identical(other.isWordRevealed, isWordRevealed) ||
+                other.isWordRevealed == isWordRevealed) &&
+            (identical(other.isShiftEnabled, isShiftEnabled) ||
+                other.isShiftEnabled == isShiftEnabled) &&
+            (identical(other.isFadaEnabled, isFadaEnabled) ||
+                other.isFadaEnabled == isFadaEnabled));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(sentences),
+      currentSentenceIndex,
+      currentWordIndex,
+      currentUserInput,
+      const DeepCollectionEquality().hash(revealedIrishWords),
+      const DeepCollectionEquality().hash(completedSentences),
+      lessonState,
+      isCurrentWordCorrect,
+      isWordRevealed,
+      isShiftEnabled,
+      isFadaEnabled);
+
+  @override
+  String toString() {
+    return 'InteractiveExerciseState(sentences: $sentences, currentSentenceIndex: $currentSentenceIndex, currentWordIndex: $currentWordIndex, currentUserInput: $currentUserInput, revealedIrishWords: $revealedIrishWords, completedSentences: $completedSentences, lessonState: $lessonState, isCurrentWordCorrect: $isCurrentWordCorrect, isWordRevealed: $isWordRevealed, isShiftEnabled: $isShiftEnabled, isFadaEnabled: $isFadaEnabled)';
   }
 }
 
 /// @nodoc
-abstract class _$$InteractiveExerciseStateImplCopyWith<$Res>
-    implements $InteractiveExerciseStateCopyWith<$Res> {
-  factory _$$InteractiveExerciseStateImplCopyWith(
-          _$InteractiveExerciseStateImpl value,
-          $Res Function(_$InteractiveExerciseStateImpl) then) =
-      __$$InteractiveExerciseStateImplCopyWithImpl<$Res>;
-  @override
+abstract mixin class $InteractiveExerciseStateCopyWith<$Res> {
+  factory $InteractiveExerciseStateCopyWith(InteractiveExerciseState value,
+          $Res Function(InteractiveExerciseState) _then) =
+      _$InteractiveExerciseStateCopyWithImpl;
   @useResult
   $Res call(
       {List<SentencePair> sentences,
@@ -156,14 +104,12 @@ abstract class _$$InteractiveExerciseStateImplCopyWith<$Res>
 }
 
 /// @nodoc
-class __$$InteractiveExerciseStateImplCopyWithImpl<$Res>
-    extends _$InteractiveExerciseStateCopyWithImpl<$Res,
-        _$InteractiveExerciseStateImpl>
-    implements _$$InteractiveExerciseStateImplCopyWith<$Res> {
-  __$$InteractiveExerciseStateImplCopyWithImpl(
-      _$InteractiveExerciseStateImpl _value,
-      $Res Function(_$InteractiveExerciseStateImpl) _then)
-      : super(_value, _then);
+class _$InteractiveExerciseStateCopyWithImpl<$Res>
+    implements $InteractiveExerciseStateCopyWith<$Res> {
+  _$InteractiveExerciseStateCopyWithImpl(this._self, this._then);
+
+  final InteractiveExerciseState _self;
+  final $Res Function(InteractiveExerciseState) _then;
 
   /// Create a copy of InteractiveExerciseState
   /// with the given fields replaced by the non-null parameter values.
@@ -182,59 +128,285 @@ class __$$InteractiveExerciseStateImplCopyWithImpl<$Res>
     Object? isShiftEnabled = null,
     Object? isFadaEnabled = null,
   }) {
-    return _then(_$InteractiveExerciseStateImpl(
+    return _then(_self.copyWith(
       sentences: null == sentences
-          ? _value._sentences
+          ? _self.sentences
           : sentences // ignore: cast_nullable_to_non_nullable
               as List<SentencePair>,
       currentSentenceIndex: null == currentSentenceIndex
-          ? _value.currentSentenceIndex
+          ? _self.currentSentenceIndex
           : currentSentenceIndex // ignore: cast_nullable_to_non_nullable
               as int,
       currentWordIndex: null == currentWordIndex
-          ? _value.currentWordIndex
+          ? _self.currentWordIndex
           : currentWordIndex // ignore: cast_nullable_to_non_nullable
               as int,
       currentUserInput: null == currentUserInput
-          ? _value.currentUserInput
+          ? _self.currentUserInput
           : currentUserInput // ignore: cast_nullable_to_non_nullable
               as String,
       revealedIrishWords: null == revealedIrishWords
-          ? _value._revealedIrishWords
+          ? _self.revealedIrishWords
           : revealedIrishWords // ignore: cast_nullable_to_non_nullable
               as List<String>,
       completedSentences: null == completedSentences
-          ? _value._completedSentences
+          ? _self.completedSentences
           : completedSentences // ignore: cast_nullable_to_non_nullable
               as List<bool>,
       lessonState: null == lessonState
-          ? _value.lessonState
+          ? _self.lessonState
           : lessonState // ignore: cast_nullable_to_non_nullable
               as LessonState,
       isCurrentWordCorrect: null == isCurrentWordCorrect
-          ? _value.isCurrentWordCorrect
+          ? _self.isCurrentWordCorrect
           : isCurrentWordCorrect // ignore: cast_nullable_to_non_nullable
               as bool,
       isWordRevealed: null == isWordRevealed
-          ? _value.isWordRevealed
+          ? _self.isWordRevealed
           : isWordRevealed // ignore: cast_nullable_to_non_nullable
               as bool,
       isShiftEnabled: null == isShiftEnabled
-          ? _value.isShiftEnabled
+          ? _self.isShiftEnabled
           : isShiftEnabled // ignore: cast_nullable_to_non_nullable
               as bool,
       isFadaEnabled: null == isFadaEnabled
-          ? _value.isFadaEnabled
+          ? _self.isFadaEnabled
           : isFadaEnabled // ignore: cast_nullable_to_non_nullable
               as bool,
     ));
   }
 }
 
+/// Adds pattern-matching-related methods to [InteractiveExerciseState].
+extension InteractiveExerciseStatePatterns on InteractiveExerciseState {
+  /// A variant of `map` that fallback to returning `orElse`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>(
+    TResult Function(_InteractiveExerciseState value)? $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _InteractiveExerciseState() when $default != null:
+        return $default(_that);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// Callbacks receives the raw object, upcasted.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case final Subclass2 value:
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>(
+    TResult Function(_InteractiveExerciseState value) $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _InteractiveExerciseState():
+        return $default(_that);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `map` that fallback to returning `null`.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case final Subclass value:
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>(
+    TResult? Function(_InteractiveExerciseState value)? $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _InteractiveExerciseState() when $default != null:
+        return $default(_that);
+      case _:
+        return null;
+    }
+  }
+
+  /// A variant of `when` that fallback to an `orElse` callback.
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return orElse();
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>(
+    TResult Function(
+            List<SentencePair> sentences,
+            int currentSentenceIndex,
+            int currentWordIndex,
+            String currentUserInput,
+            List<String> revealedIrishWords,
+            List<bool> completedSentences,
+            LessonState lessonState,
+            bool isCurrentWordCorrect,
+            bool isWordRevealed,
+            bool isShiftEnabled,
+            bool isFadaEnabled)?
+        $default, {
+    required TResult orElse(),
+  }) {
+    final _that = this;
+    switch (_that) {
+      case _InteractiveExerciseState() when $default != null:
+        return $default(
+            _that.sentences,
+            _that.currentSentenceIndex,
+            _that.currentWordIndex,
+            _that.currentUserInput,
+            _that.revealedIrishWords,
+            _that.completedSentences,
+            _that.lessonState,
+            _that.isCurrentWordCorrect,
+            _that.isWordRevealed,
+            _that.isShiftEnabled,
+            _that.isFadaEnabled);
+      case _:
+        return orElse();
+    }
+  }
+
+  /// A `switch`-like method, using callbacks.
+  ///
+  /// As opposed to `map`, this offers destructuring.
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case Subclass2(:final field2):
+  ///     return ...;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>(
+    TResult Function(
+            List<SentencePair> sentences,
+            int currentSentenceIndex,
+            int currentWordIndex,
+            String currentUserInput,
+            List<String> revealedIrishWords,
+            List<bool> completedSentences,
+            LessonState lessonState,
+            bool isCurrentWordCorrect,
+            bool isWordRevealed,
+            bool isShiftEnabled,
+            bool isFadaEnabled)
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _InteractiveExerciseState():
+        return $default(
+            _that.sentences,
+            _that.currentSentenceIndex,
+            _that.currentWordIndex,
+            _that.currentUserInput,
+            _that.revealedIrishWords,
+            _that.completedSentences,
+            _that.lessonState,
+            _that.isCurrentWordCorrect,
+            _that.isWordRevealed,
+            _that.isShiftEnabled,
+            _that.isFadaEnabled);
+      case _:
+        throw StateError('Unexpected subclass');
+    }
+  }
+
+  /// A variant of `when` that fallback to returning `null`
+  ///
+  /// It is equivalent to doing:
+  /// ```dart
+  /// switch (sealedClass) {
+  ///   case Subclass(:final field):
+  ///     return ...;
+  ///   case _:
+  ///     return null;
+  /// }
+  /// ```
+
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>(
+    TResult? Function(
+            List<SentencePair> sentences,
+            int currentSentenceIndex,
+            int currentWordIndex,
+            String currentUserInput,
+            List<String> revealedIrishWords,
+            List<bool> completedSentences,
+            LessonState lessonState,
+            bool isCurrentWordCorrect,
+            bool isWordRevealed,
+            bool isShiftEnabled,
+            bool isFadaEnabled)?
+        $default,
+  ) {
+    final _that = this;
+    switch (_that) {
+      case _InteractiveExerciseState() when $default != null:
+        return $default(
+            _that.sentences,
+            _that.currentSentenceIndex,
+            _that.currentWordIndex,
+            _that.currentUserInput,
+            _that.revealedIrishWords,
+            _that.completedSentences,
+            _that.lessonState,
+            _that.isCurrentWordCorrect,
+            _that.isWordRevealed,
+            _that.isShiftEnabled,
+            _that.isFadaEnabled);
+      case _:
+        return null;
+    }
+  }
+}
+
 /// @nodoc
 
-class _$InteractiveExerciseStateImpl extends _InteractiveExerciseState {
-  const _$InteractiveExerciseStateImpl(
+class _InteractiveExerciseState extends InteractiveExerciseState {
+  const _InteractiveExerciseState(
       {required final List<SentencePair> sentences,
       required this.currentSentenceIndex,
       required this.currentWordIndex,
@@ -294,16 +466,20 @@ class _$InteractiveExerciseStateImpl extends _InteractiveExerciseState {
   @override
   final bool isFadaEnabled;
 
+  /// Create a copy of InteractiveExerciseState
+  /// with the given fields replaced by the non-null parameter values.
   @override
-  String toString() {
-    return 'InteractiveExerciseState(sentences: $sentences, currentSentenceIndex: $currentSentenceIndex, currentWordIndex: $currentWordIndex, currentUserInput: $currentUserInput, revealedIrishWords: $revealedIrishWords, completedSentences: $completedSentences, lessonState: $lessonState, isCurrentWordCorrect: $isCurrentWordCorrect, isWordRevealed: $isWordRevealed, isShiftEnabled: $isShiftEnabled, isFadaEnabled: $isFadaEnabled)';
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$InteractiveExerciseStateCopyWith<_InteractiveExerciseState> get copyWith =>
+      __$InteractiveExerciseStateCopyWithImpl<_InteractiveExerciseState>(
+          this, _$identity);
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$InteractiveExerciseStateImpl &&
+            other is _InteractiveExerciseState &&
             const DeepCollectionEquality()
                 .equals(other._sentences, _sentences) &&
             (identical(other.currentSentenceIndex, currentSentenceIndex) ||
@@ -343,58 +519,106 @@ class _$InteractiveExerciseStateImpl extends _InteractiveExerciseState {
       isShiftEnabled,
       isFadaEnabled);
 
+  @override
+  String toString() {
+    return 'InteractiveExerciseState(sentences: $sentences, currentSentenceIndex: $currentSentenceIndex, currentWordIndex: $currentWordIndex, currentUserInput: $currentUserInput, revealedIrishWords: $revealedIrishWords, completedSentences: $completedSentences, lessonState: $lessonState, isCurrentWordCorrect: $isCurrentWordCorrect, isWordRevealed: $isWordRevealed, isShiftEnabled: $isShiftEnabled, isFadaEnabled: $isFadaEnabled)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$InteractiveExerciseStateCopyWith<$Res>
+    implements $InteractiveExerciseStateCopyWith<$Res> {
+  factory _$InteractiveExerciseStateCopyWith(_InteractiveExerciseState value,
+          $Res Function(_InteractiveExerciseState) _then) =
+      __$InteractiveExerciseStateCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {List<SentencePair> sentences,
+      int currentSentenceIndex,
+      int currentWordIndex,
+      String currentUserInput,
+      List<String> revealedIrishWords,
+      List<bool> completedSentences,
+      LessonState lessonState,
+      bool isCurrentWordCorrect,
+      bool isWordRevealed,
+      bool isShiftEnabled,
+      bool isFadaEnabled});
+}
+
+/// @nodoc
+class __$InteractiveExerciseStateCopyWithImpl<$Res>
+    implements _$InteractiveExerciseStateCopyWith<$Res> {
+  __$InteractiveExerciseStateCopyWithImpl(this._self, this._then);
+
+  final _InteractiveExerciseState _self;
+  final $Res Function(_InteractiveExerciseState) _then;
+
   /// Create a copy of InteractiveExerciseState
   /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   @pragma('vm:prefer-inline')
-  _$$InteractiveExerciseStateImplCopyWith<_$InteractiveExerciseStateImpl>
-      get copyWith => __$$InteractiveExerciseStateImplCopyWithImpl<
-          _$InteractiveExerciseStateImpl>(this, _$identity);
+  $Res call({
+    Object? sentences = null,
+    Object? currentSentenceIndex = null,
+    Object? currentWordIndex = null,
+    Object? currentUserInput = null,
+    Object? revealedIrishWords = null,
+    Object? completedSentences = null,
+    Object? lessonState = null,
+    Object? isCurrentWordCorrect = null,
+    Object? isWordRevealed = null,
+    Object? isShiftEnabled = null,
+    Object? isFadaEnabled = null,
+  }) {
+    return _then(_InteractiveExerciseState(
+      sentences: null == sentences
+          ? _self._sentences
+          : sentences // ignore: cast_nullable_to_non_nullable
+              as List<SentencePair>,
+      currentSentenceIndex: null == currentSentenceIndex
+          ? _self.currentSentenceIndex
+          : currentSentenceIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+      currentWordIndex: null == currentWordIndex
+          ? _self.currentWordIndex
+          : currentWordIndex // ignore: cast_nullable_to_non_nullable
+              as int,
+      currentUserInput: null == currentUserInput
+          ? _self.currentUserInput
+          : currentUserInput // ignore: cast_nullable_to_non_nullable
+              as String,
+      revealedIrishWords: null == revealedIrishWords
+          ? _self._revealedIrishWords
+          : revealedIrishWords // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      completedSentences: null == completedSentences
+          ? _self._completedSentences
+          : completedSentences // ignore: cast_nullable_to_non_nullable
+              as List<bool>,
+      lessonState: null == lessonState
+          ? _self.lessonState
+          : lessonState // ignore: cast_nullable_to_non_nullable
+              as LessonState,
+      isCurrentWordCorrect: null == isCurrentWordCorrect
+          ? _self.isCurrentWordCorrect
+          : isCurrentWordCorrect // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isWordRevealed: null == isWordRevealed
+          ? _self.isWordRevealed
+          : isWordRevealed // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isShiftEnabled: null == isShiftEnabled
+          ? _self.isShiftEnabled
+          : isShiftEnabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isFadaEnabled: null == isFadaEnabled
+          ? _self.isFadaEnabled
+          : isFadaEnabled // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
 }
 
-abstract class _InteractiveExerciseState extends InteractiveExerciseState {
-  const factory _InteractiveExerciseState(
-      {required final List<SentencePair> sentences,
-      required final int currentSentenceIndex,
-      required final int currentWordIndex,
-      required final String currentUserInput,
-      required final List<String> revealedIrishWords,
-      required final List<bool> completedSentences,
-      required final LessonState lessonState,
-      required final bool isCurrentWordCorrect,
-      required final bool isWordRevealed,
-      required final bool isShiftEnabled,
-      required final bool isFadaEnabled}) = _$InteractiveExerciseStateImpl;
-  const _InteractiveExerciseState._() : super._();
-
-  @override
-  List<SentencePair> get sentences;
-  @override
-  int get currentSentenceIndex;
-  @override
-  int get currentWordIndex;
-  @override
-  String get currentUserInput;
-  @override
-  List<String> get revealedIrishWords;
-  @override
-  List<bool> get completedSentences;
-  @override
-  LessonState get lessonState;
-  @override
-  bool get isCurrentWordCorrect;
-  @override
-  bool get isWordRevealed;
-  @override
-  bool get isShiftEnabled;
-  @override
-  bool get isFadaEnabled;
-
-  /// Create a copy of InteractiveExerciseState
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$InteractiveExerciseStateImplCopyWith<_$InteractiveExerciseStateImpl>
-      get copyWith => throw _privateConstructorUsedError;
-}
+// dart format on

--- a/lib/features/lesson/repository/connectivity_repository.g.dart
+++ b/lib/features/lesson/repository/connectivity_repository.g.dart
@@ -6,21 +6,57 @@ part of 'connectivity_repository.dart';
 // RiverpodGenerator
 // **************************************************************************
 
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(ConnectivityRepo)
+const connectivityRepoProvider = ConnectivityRepoProvider._();
+
+final class ConnectivityRepoProvider
+    extends $NotifierProvider<ConnectivityRepo, BaseConnectivityRepository> {
+  const ConnectivityRepoProvider._()
+      : super(
+          from: null,
+          argument: null,
+          retry: null,
+          name: r'connectivityRepoProvider',
+          isAutoDispose: false,
+          dependencies: null,
+          $allTransitiveDependencies: null,
+        );
+
+  @override
+  String debugGetCreateSourceHash() => _$connectivityRepoHash();
+
+  @$internal
+  @override
+  ConnectivityRepo create() => ConnectivityRepo();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(BaseConnectivityRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<BaseConnectivityRepository>(value),
+    );
+  }
+}
+
 String _$connectivityRepoHash() => r'434420ae00703c775fd840c48cb956273ae4704f';
 
-/// See also [ConnectivityRepo].
-@ProviderFor(ConnectivityRepo)
-final connectivityRepoProvider =
-    NotifierProvider<ConnectivityRepo, BaseConnectivityRepository>.internal(
-  ConnectivityRepo.new,
-  name: r'connectivityRepoProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$connectivityRepoHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
-
-typedef _$ConnectivityRepo = Notifier<BaseConnectivityRepository>;
-// ignore_for_file: type=lint
-// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package
+abstract class _$ConnectivityRepo
+    extends $Notifier<BaseConnectivityRepository> {
+  BaseConnectivityRepository build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref = this.ref
+        as $Ref<BaseConnectivityRepository, BaseConnectivityRepository>;
+    final element = ref.element as $ClassProviderElement<
+        AnyNotifier<BaseConnectivityRepository, BaseConnectivityRepository>,
+        BaseConnectivityRepository,
+        Object?,
+        Object?>;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/features/lesson/widget/custom_keyboard_widget.dart
+++ b/lib/features/lesson/widget/custom_keyboard_widget.dart
@@ -1,6 +1,7 @@
 // lib/presentation/widgets/custom_keyboard_widget.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 
 // Providers
 final shiftStateProvider = StateProvider<bool>((ref) => false);

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Home')),
+      body: Center(
+        child: Wrap(
+          spacing: 12,
+          children: [
+            ElevatedButton(
+              onPressed: () {
+                // /lesson/:id
+                context.pushNamed('lesson',
+                    pathParameters: {'id': 'dummy_lesson'});
+              },
+              child: const Text('Open Lesson 1'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                // /lesson2/:id
+                context.pushNamed('lesson2',
+                    pathParameters: {'id': 'dummy_lesson_2'});
+              },
+              child: const Text('Open Lesson 2'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -7,6 +7,7 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      key: const Key('lesson_list_scaffold'),
       appBar: AppBar(title: const Text('Home')),
       body: Center(
         child: Wrap(

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
+import 'routes.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen();
@@ -14,17 +14,13 @@ class HomeScreen extends StatelessWidget {
           children: [
             ElevatedButton(
               onPressed: () {
-                // /lesson/:id
-                context.pushNamed('lesson',
-                    pathParameters: {'id': 'dummy_lesson'});
+                const LessonRoute(id: 'dummy_lesson1').go(context);
               },
               child: const Text('Open Lesson 1'),
             ),
             ElevatedButton(
               onPressed: () {
-                // /lesson2/:id
-                context.pushNamed('lesson2',
-                    pathParameters: {'id': 'dummy_lesson_2'});
+                const LessonRoute(id: 'dummy_lesson2').go(context);
               },
               child: const Text('Open Lesson 2'),
             ),

--- a/lib/home_screen.dart
+++ b/lib/home_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'routes.dart';
 
 class HomeScreen extends StatelessWidget {
-  const HomeScreen();
+  const HomeScreen({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/lesson_screen.dart
+++ b/lib/lesson_screen.dart
@@ -15,6 +15,7 @@ class LessonScreen extends ConsumerWidget {
         ref.watch(lessonDefinitionProvider(plantedTreeId));
 
     return Scaffold(
+      key: const Key('lesson_scaffold'),
       appBar: AppBar(
         title: lessonDefinitionAsync.when(
           data: (lessonDef) => Text(lessonDef.lessonName),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:sionnach_ui_community/lesson_screen.dart';
 import 'package:go_router/go_router.dart';
 import 'home_screen.dart';
+import 'app_router.dart';
 
 void main() {
   runApp(const ProviderScope(child: MyApp()));
@@ -19,38 +20,7 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      routerConfig: _router,
+      routerConfig: appRouter,
     );
   }
 }
-
-final _router = GoRouter(
-  initialLocation: '/', //Home screen
-  routes: [
-    // selection home
-    GoRoute(
-      path: '/',
-      builder: (context, state) => const HomeScreen(),
-    ),
-
-    // First lesson route
-    GoRoute(
-      path: '/lesson/:id',
-      name: 'lesson',
-      builder: (context, state) {
-        final id = state.pathParameters['id']!;
-        return LessonScreen(plantedTreeId: id);
-      },
-    ),
-
-    // Additional feature route
-    GoRoute(
-      path: '/lesson2/:id',
-      name: 'lesson2',
-      builder: (context, state) {
-        final id = state.pathParameters['id']!;
-        return LessonScreen(plantedTreeId: id);
-      },
-    ),
-  ],
-);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:sionnach_ui_community/lesson_screen.dart';
-import 'package:go_router/go_router.dart';
-import 'home_screen.dart';
 import 'app_router.dart';
 
 void main() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:sionnach_ui_community/lesson_screen.dart';
+import 'package:go_router/go_router.dart';
+import 'home_screen.dart';
 
 void main() {
   runApp(const ProviderScope(child: MyApp()));
@@ -11,15 +13,44 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'Sionnach UI Community',
       theme: ThemeData(
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: const LessonScreen(
-        plantedTreeId: 'dummy_lesson', // Using a dummy ID
-      ),
+      routerConfig: _router,
     );
   }
 }
+
+final _router = GoRouter(
+  initialLocation: '/', //Home screen
+  routes: [
+    // selection home
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const HomeScreen(),
+    ),
+
+    // First lesson route
+    GoRoute(
+      path: '/lesson/:id',
+      name: 'lesson',
+      builder: (context, state) {
+        final id = state.pathParameters['id']!;
+        return LessonScreen(plantedTreeId: id);
+      },
+    ),
+
+    // Additional feature route
+    GoRoute(
+      path: '/lesson2/:id',
+      name: 'lesson2',
+      builder: (context, state) {
+        final id = state.pathParameters['id']!;
+        return LessonScreen(plantedTreeId: id);
+      },
+    ),
+  ],
+);

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -78,7 +78,10 @@ class LessonRoute extends GoRouteData with $LessonRoute {
   final String id;
 
   @override
-  Widget build(BuildContext context, GoRouterState state) {
-    return LessonScreen(plantedTreeId: id);
+  Page<void> buildPage(BuildContext context, GoRouterState state) {
+    return MaterialPage<void>(
+      key: const ValueKey('lesson_page'),
+      child: LessonScreen(plantedTreeId: id),
+    );
   }
 }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -31,7 +31,8 @@ class _RootNavBar extends StatelessWidget {
 
   int get _index {
     final loc = state.uri.toString();
-    if (loc.startsWith('/lesson')) return 1;
+    if (loc.startsWith('/lesson/dummy_lesson1')) return 1;
+    if (loc.startsWith('/lesson/dummy_lesson2')) return 2;
     return 0; // /lessons
   }
 
@@ -45,13 +46,17 @@ class _RootNavBar extends StatelessWidget {
             const LessonsListRoute().go(context);
             break;
           case 1:
-            const LessonRoute(id: 'dummy_lesson').go(context);
+            const LessonRoute(id: 'dummy_lesson1').go(context);
+            break;
+          case 2:
+            const LessonRoute(id: 'dummy_lesson2').go(context);
             break;
         }
       },
       destinations: const [
         NavigationDestination(icon: Icon(Icons.menu_book), label: 'Lessons'),
-        NavigationDestination(icon: Icon(Icons.school), label: 'Lesson'),
+        NavigationDestination(icon: Icon(Icons.school), label: 'Lesson 1'),
+        NavigationDestination(icon: Icon(Icons.school), label: 'Lesson 2'),
       ],
     );
   }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'lesson_screen.dart';
+import 'home_screen.dart';
+
+part 'routes.g.dart';
+
+/// A shell with a bottom nav (or side rail) that hosts multiple branches.
+@TypedShellRoute<RootShellRoute>(
+  routes: [
+    TypedGoRoute<LessonsListRoute>(path: '/lessons'),
+    TypedGoRoute<LessonRoute>(path: '/lesson/:id'),
+  ],
+)
+class RootShellRoute extends ShellRouteData {
+  const RootShellRoute();
+
+  @override
+  Widget builder(BuildContext context, GoRouterState state, Widget navigator) {
+    return Scaffold(
+      body: navigator,
+      bottomNavigationBar: _RootNavBar(state: state),
+    );
+  }
+}
+
+class _RootNavBar extends StatelessWidget {
+  const _RootNavBar({required this.state});
+  final GoRouterState state;
+
+  int get _index {
+    final loc = state.uri.toString();
+    if (loc.startsWith('/lesson')) return 1;
+    return 0; // /lessons
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return NavigationBar(
+      selectedIndex: _index,
+      onDestinationSelected: (i) {
+        switch (i) {
+          case 0:
+            const LessonsListRoute().go(context);
+            break;
+          case 1:
+            const LessonRoute(id: 'dummy_lesson').go(context);
+            break;
+        }
+      },
+      destinations: const [
+        NavigationDestination(icon: Icon(Icons.menu_book), label: 'Lessons'),
+        NavigationDestination(icon: Icon(Icons.school), label: 'Lesson'),
+      ],
+    );
+  }
+}
+
+/// /lessons (e.g., a list page)
+class LessonsListRoute extends GoRouteData with $LessonsListRoute {
+  const LessonsListRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return const HomeScreen();
+  }
+}
+
+/// /lesson/:id — typed path param
+class LessonRoute extends GoRouteData with $LessonRoute {
+  const LessonRoute({required this.id});
+  final String id;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) {
+    return LessonScreen(plantedTreeId: id);
+  }
+}

--- a/lib/routes.g.dart
+++ b/lib/routes.g.dart
@@ -1,0 +1,79 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'routes.dart';
+
+// **************************************************************************
+// GoRouterGenerator
+// **************************************************************************
+
+List<RouteBase> get $appRoutes => [
+      $rootShellRoute,
+    ];
+
+RouteBase get $rootShellRoute => ShellRouteData.$route(
+      factory: $RootShellRouteExtension._fromState,
+      routes: [
+        GoRouteData.$route(
+          path: '/lessons',
+          factory: $LessonsListRoute._fromState,
+        ),
+        GoRouteData.$route(
+          path: '/lesson/:id',
+          factory: $LessonRoute._fromState,
+        ),
+      ],
+    );
+
+extension $RootShellRouteExtension on RootShellRoute {
+  static RootShellRoute _fromState(GoRouterState state) =>
+      const RootShellRoute();
+}
+
+mixin $LessonsListRoute on GoRouteData {
+  static LessonsListRoute _fromState(GoRouterState state) =>
+      const LessonsListRoute();
+
+  @override
+  String get location => GoRouteData.$location(
+        '/lessons',
+      );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $LessonRoute on GoRouteData {
+  static LessonRoute _fromState(GoRouterState state) => LessonRoute(
+        id: state.pathParameters['id']!,
+      );
+
+  LessonRoute get _self => this as LessonRoute;
+
+  @override
+  String get location => GoRouteData.$location(
+        '/lesson/${Uri.encodeComponent(_self.id)}',
+      );
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.6.0"
+  analyzer_buffer:
+    dependency: transitive
+    description:
+      name: analyzer_buffer
+      sha256: f7833bee67c03c37241c67f8741b17cc501b69d9758df7a5a4a13ed6c947be43
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.10"
   analyzer_plugin:
     dependency: transitive
     description:
@@ -53,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "51dc711996cbf609b90cbe5b335bbce83143875a9d58e4b5c6d3c4f684d3dda7"
+      sha256: "7d95cbbb1526ab5ae977df9b4cc660963b9b27f6d1075c0b34653868911385e4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "3.0.0"
   build_config:
     dependency: transitive
     description:
@@ -77,26 +85,26 @@ packages:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: ee4257b3f20c0c90e72ed2b57ad637f694ccba48839a821e87db762548c22a62
+      sha256: "38c9c339333a09b090a638849a4c56e70a404c6bdd3b511493addfbc113b60c2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "3.0.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "382a4d649addbfb7ba71a3631df0ec6a45d5ab9b098638144faf27f02778eb53"
+      sha256: b971d4a1c789eba7be3e6fe6ce5e5b50fd3719e3cb485b3fad6d04358304351d
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.4"
+    version: "2.6.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "85fbbb1036d576d966332a3f5ce83f2ce66a40bea1a94ad2d5fc29a19a0d3792"
+      sha256: c04e612ca801cd0928ccdb891c263a2b1391cb27940a5ea5afcf9ba894de5d62
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.2"
+    version: "9.2.0"
   built_collection:
     dependency: transitive
     description:
@@ -129,6 +137,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
@@ -177,6 +193,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  coverage:
+    dependency: transitive
+    description:
+      name: coverage
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
@@ -197,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: custom_lint_core
-      sha256: "31110af3dde9d29fb10828ca33f1dce24d2798477b167675543ce3d208dee8be"
+      sha256: cc4684d22ca05bf0a4a51127e19a8aea576b42079ed2bc9e956f11aaebe35dd1
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.5"
+    version: "0.8.0"
   custom_lint_visitor:
     dependency: transitive
     description:
@@ -274,10 +298,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      sha256: "9e2d6907f12cc7d23a846847615941bddee8709bf2bfd274acdf5e80bcf22fde"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "3.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -292,18 +316,18 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "59a584c24b3acdc5250bb856d0d3e9c0b798ed14a4af1ddb7dc1c7b41df91c9c"
+      sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.8"
+    version: "3.2.3"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -324,18 +348,18 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: c5fa45fa502ee880839e3b2152d987c44abae26d064a2376d4aad434cf0f7b15
+      sha256: d8f590a69729f719177ea68eb1e598295e8dbc41bbc247fed78b2c8a25660d7c
       url: "https://pub.dev"
     source: hosted
-    version: "12.1.3"
+    version: "16.3.0"
   go_router_builder:
     dependency: "direct dev"
     description:
       name: go_router_builder
-      sha256: "7f6f4bfb97cadc3d25378a0237fe4ddd98b54d6094b5a5c158b775a2cc30843e"
+      sha256: e0646fb5586e04e1df92678f539059f38e4314848f06dd4f3cd87fed434e16b5
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "4.1.1"
   graphs:
     dependency: transitive
     description:
@@ -404,10 +428,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      sha256: "33a040668b31b320aafa4822b7b1e177e163fc3c1e835c6750319d4ab23aa6fe"
       url: "https://pub.dev"
     source: hosted
-    version: "6.9.5"
+    version: "6.11.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -480,6 +504,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mockito:
+    dependency: transitive
+    description:
+      name: mockito
+      sha256: "2314cbe9165bcd16106513df9cf3c3224713087f09723b128928dc11a4379f99"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.5.0"
   mocktail:
     dependency: "direct dev"
     description:
@@ -496,6 +528,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   package_config:
     dependency: transitive
     description:
@@ -556,34 +596,34 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      sha256: c406de02bff19d920b832bddfb8283548bfa05ce41c59afba57ce643e116aa59
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "3.0.3"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: "837a6dc33f490706c7f4632c516bcd10804ee4d9ccc8046124ca56388715fdf3"
+      sha256: a0f68adb078b790faa3c655110a017f9a7b7b079a57bbd40f540e80dce5fcd29
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.9"
+    version: "1.0.0-dev.7"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: e14b0bf45b71326654e2705d462f21b958f987087be850afd60578fcd502d1b8
+      sha256: "7230014155777fc31ba3351bc2cb5a3b5717b11bfafe52b1553cb47d385f8897"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.1"
+    version: "3.0.3"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "120d3310f687f43e7011bb213b90a436f1bbc300f0e4b251a72c39bccb017a4f"
+      sha256: "49894543a42cf7a9954fc4e7366b6d3cb2e6ec0fa07775f660afcdd92d097702"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.4"
+    version: "3.0.3"
   shelf:
     dependency: transitive
     description:
@@ -592,6 +632,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  shelf_static:
+    dependency: transitive
+    description:
+      name: shelf_static
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -609,10 +665,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
+      sha256: "7b19d6ba131c6eb98bfcbf8d56c1a7002eba438af2e7ae6f8398b2b0f4f381e3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.1.0"
   source_helper:
     dependency: transitive
     description:
@@ -621,6 +677,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.7"
+  source_map_stack_trace:
+    dependency: transitive
+    description:
+      name: source_map_stack_trace
+      sha256: c0713a43e323c3302c2abe2a1cc89aa057a387101ebd280371d6a6c9fa68516b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  source_maps:
+    dependency: transitive
+    description:
+      name: source_maps
+      sha256: "190222579a448b03896e0ca6eca5998fa810fda630c1d65e2f78b3f638f54812"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.13"
   source_span:
     dependency: transitive
     description:
@@ -685,6 +757,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  test:
+    dependency: transitive
+    description:
+      name: test
+      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.26.2"
   test_api:
     dependency: transitive
     description:
@@ -693,6 +773,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.6"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.11"
   timing:
     dependency: transitive
     description:
@@ -765,6 +853,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   xml:
     dependency: transitive
     description:
@@ -783,4 +879,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sionnach_ui_community
-description: "A new Flutter project."
+description: 'A new Flutter project.'
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
@@ -30,12 +30,12 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_riverpod: ^2.4.0
-  riverpod_annotation: ^2.1.1
-  freezed_annotation: ^2.2.0
+  flutter_riverpod: ^3.0.3
+  riverpod_annotation: ^3.0.3
+  freezed_annotation: ^3.1.0
   json_annotation: ^4.8.1
   cupertino_icons: ^1.0.2
-  go_router: ^12.1.1
+  go_router: ^16.2.0
   internet_connection_checker_plus: ^2.9.0
   connectivity_plus: ^7.0.0
   fake_async: ^1.3.3
@@ -51,18 +51,17 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
   build_runner: ^2.4.6
-  riverpod_generator: ^2.2.3
-  freezed: ^2.4.1
+  riverpod_generator: ^3.0.3
+  freezed: ^3.2.3
   json_serializable: ^6.7.1
   mocktail: ^1.0.1
-  go_router_builder: ^2.3.3
+  go_router_builder: ^4.1.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
 # The following section is specific to Flutter packages.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/test/fakes/manual_router.dart
+++ b/test/fakes/manual_router.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/foundation.dart';
+import 'package:go_router/go_router.dart';
+import 'package:sionnach_ui_community/routes.dart';
+
+GoRouter buildTestRouter({String? initialLocation}) {
+  return GoRouter(
+    routes: $appRoutes,
+    initialLocation: initialLocation ?? const LessonsListRoute().location,
+    debugLogDiagnostics: kDebugMode,
+  );
+}

--- a/test/routes/routes_test.dart
+++ b/test/routes/routes_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../fakes/manual_router.dart';
+import 'package:sionnach_ui_community/routes.dart';
+
+Widget _appWith(GoRouter router) {
+  return ProviderScope(
+    overrides: const [],
+    child: MaterialApp.router(routerConfig: router),
+  );
+}
+
+const defaultMinWidth = 430.0;
+const defaultMinHeight = 900.0;
+
+void main() {
+  setUp(() {});
+
+  //Explicitly set size to avoid rendering overflow issues in current layout
+  setSurfaceSize(WidgetTester tester, {double? height, double? width}) async {
+    await tester.binding.setSurfaceSize(
+        Size(width ?? defaultMinWidth, height ?? defaultMinHeight));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+  }
+
+  testWidgets('initial route shows Lessons list', (tester) async {
+    final router = buildTestRouter(
+      initialLocation: const LessonsListRoute().location,
+    );
+
+    await tester.pumpWidget(_appWith(router));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('lesson_list_scaffold')), findsOneWidget);
+    expect(find.text('Lessons'), findsOneWidget);
+  });
+
+  testWidgets('initial route shows Lessons', (tester) async {
+    await setSurfaceSize(tester);
+
+    final router = buildTestRouter(
+      initialLocation: const LessonRoute(id: 'dummy_lesson1').location,
+    );
+
+    await tester.pumpWidget(_appWith(router));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('lesson_scaffold')), findsOneWidget);
+    expect(find.text('Hello'), findsOneWidget);
+  });
+
+  testWidgets('deep link to /lesson/:id shows that lesson', (tester) async {
+    await setSurfaceSize(tester);
+
+    final loc = const LessonRoute(id: 'dummy_lesson1').location;
+    final router = buildTestRouter(initialLocation: loc);
+
+    await tester.pumpWidget(_appWith(router));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('lesson_scaffold')), findsOneWidget);
+    expect(find.textContaining('Hello'), findsOneWidget);
+  });
+
+  testWidgets('navigate using .go() to another lesson', (tester) async {
+    await setSurfaceSize(tester);
+
+    final router = buildTestRouter(
+      initialLocation: const LessonsListRoute().location,
+    );
+
+    await tester.pumpWidget(_appWith(router));
+    await tester.pumpAndSettle();
+
+    // Navigate programmatically using route
+    router.go(const LessonRoute(id: 'abc123').location);
+
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('lesson_scaffold')), findsOneWidget);
+    expect(find.textContaining('Hello'), findsOneWidget);
+  });
+
+  testWidgets('bottom nav taps switch between list and lesson', (tester) async {
+    await setSurfaceSize(tester);
+
+    final router = buildTestRouter(
+      initialLocation: const LessonsListRoute().location,
+    );
+
+    await tester.pumpWidget(_appWith(router));
+    await tester.pumpAndSettle();
+
+    // On list
+    expect(find.byKey(const Key('lesson_list_scaffold')), findsOneWidget);
+
+    // Tap "Lesson 1" destination in NavigationBar
+    await tester.tap(find.text('Lesson 1'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('lesson_scaffold')), findsOneWidget);
+    expect(find.textContaining('Hello'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
An implementation of gorouter with route generation and simple sample routes.

This uses an updated version of GoRouter, and corresponding dependency updates for both freezed and riverpod, which required some very minimal migration updates.

Includes a bottom rail and button list for sample navigating.

Testing requires an explicit height setting for now, to avoid overflow rendering issues from the base exercise ui.

<img width="1190" height="837" alt="Screenshot 2025-11-10 at 1 58 31 PM" src="https://github.com/user-attachments/assets/5cb8ae99-4d1c-4167-849c-b6d39c2d2e13" />
<img width="1165" height="880" alt="Screenshot 2025-11-10 at 1 58 46 PM" src="https://github.com/user-attachments/assets/f5a3cf57-4ba3-45a7-aadb-e0d55085695f" />
<img width="1176" height="880" alt="Screenshot 2025-11-10 at 1 59 00 PM" src="https://github.com/user-attachments/assets/53a5f591-ef4c-4f34-9931-5cfb2015f442" />
